### PR TITLE
Switch test coverage to nyc

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple tool for high-fiving your tech stack",
   "main": "src/index.js",
   "scripts": {
-    "test": "istanbul cover _mocha test",
+    "test": "nyc mocha",
     "watch:test": "mocha:watch",
     "lint": "eslint src",
     "validate": "npm-run-all --parallel lint test"
@@ -24,9 +24,15 @@
     "chai-spies": "^0.7.1",
     "eslint": "^3.8.1",
     "eslint-plugin-flowtype": "^2.25.0",
-    "istanbul": "^1.1.0-alpha.1",
     "mocha": "^3.1.2",
-    "npm-run-all": "^3.1.2"
+    "npm-run-all": "^3.1.2",
+    "nyc": "^10.0.0"
+  },
+  "nyc": {
+    "check-coverage": true,
+    "functions": 90,
+    "lines": 90,
+    "statements": 90
   },
   "dependencies": {}
 }

--- a/src/index-test.js
+++ b/src/index-test.js
@@ -1,8 +1,8 @@
-var chai            = require('chai');
-var spies           = require('chai-spies');
-var expect          = chai.expect;
-var backpat         = require('./index').backpat;
-var vars            = require('./index');
+var chai    = require('chai');
+var spies   = require('chai-spies');
+var expect  = chai.expect;
+var backpat = require('./index').backpat;
+var vars    = require('./index');
 
 chai.use(spies);
 
@@ -20,7 +20,7 @@ describe('Backpat', function() {
     expect(spy).to.be.spy;
     backpat(spy);
     // asynchronous nature of backpat function makes this very difficult to test
-    expect(spy).to.have.been.called();
+    vars.event.on('complete', expect(spy).to.have.been.called.once());
   });
   describe('Properties', function() {
     describe('rootDir', function() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 var fs           = require('fs');
-var EventEmitter = require('events').EventEmitter;
+var EventEmitter = require('events');
 var helpers      = require('./helpers');
 
 exports.rootDir = process.cwd() + '/';


### PR DESCRIPTION
Istanbul and nyc merged recently--the two are now one. Istanbul still creates the test coverage documents but nyc is the command line tool, which in my opinion is better.