### PR TITLE
Refactor utility functions to functional paradigm

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,54 @@
+{
+
+  "extends": [
+    "eslint:recommended",
+    "plugin:flowtype/recommended"
+  ],
+
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "impliedStrict": true,
+      "experimentalObjectRestSpread": true
+    }
+  },
+
+  "env": {
+    "browser": false,
+    "node": true,
+    "es6": true,
+    "mocha": true
+  },
+
+  "plugins": [
+    "flowtype"
+  ],
+
+  "globals": {
+    "define": true
+  },
+
+  "settings": {
+    "flowtype": {
+      "onlyFilesWithFlowAnnotation": true
+    }
+  },
+
+  "rules": {
+    "strict": ["error", "global"],
+    "no-unused-vars": ["error", { "vars": "all", "args": "none", "caughtErrors": "none" }],
+    "no-console": ["error", { allow: ["warn", "error"] }],
+    "camelcase": ["error", { "properties": "always" }],
+    "consistent-return": "error",
+    "arrow-spacing": "error",
+    "arrow-parens": ["error", "always"],
+    "arrow-body-style": ["error", "as-needed"],
+    "semi": ["error", "always"],
+    "no-confusing-arrow": ["error", { "allowParens": false }],
+    "no-constant-condition": "error",
+    "no-labels": "error",
+    "no-multiple-empty-lines": ["error", { max: 1, maxEOF: 1 }],
+    "func-style": "off",
+  }
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,7 @@ module.exports = {
 
   "rules": {
     "strict": ["error", "global"],
-    "no-unused-vars": ["error", { "vars": "all", "args": "all", "caughtErrors": "none" }],
+    "no-unused-vars": ["error", { "vars": "all", "args": "none", "caughtErrors": "none" }],
     "no-console": ["error", { allow: ["warn", "error"] }],
     "camelcase": ["error", { "properties": "always" }],
     "consistent-return": "error",

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,3 @@
 eslint:
   enabled: true
+  config_file: .eslintrc.js

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,3 @@
 eslint:
   enabled: true
-  config_file: .eslintrc.js
+  config_file: .eslintrc

--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ test
 # Misc Dev Configs
 .babelrc
 .eslintrc.js
+.eslintrc
 .flowconfig
 .gitignore
 .hound.yml

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,25 @@
+# This is still in development. Attempting to strip the npm package to its barest possible.
+
+# Test configs
+test
+
+# Misc Dev Configs
+.babelrc
+.eslintrc.js
+.flowconfig
+.gitignore
+.hound.yml
+.travis.yml
+.npmignore
+
+# Source
+src
+
+# Dev docs
+CODE-OF-CONDUCT.md
+CONTRIBUTING.md
+ISSUE_TEMPLATE.md
+
 # Logs
 logs
 *.log

--- a/.npmignore
+++ b/.npmignore
@@ -38,3 +38,6 @@ jspm_packages
 
 # VS Code configs
 .vscode
+
+# Dev run script
+runner.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - 6
   - 5
   - 4
-  - 0.12.0
 branches:
   only:
     - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased (0.6.0 candidate)
+## 0.6.0 - 2017-1-5
 ### Added
 - Configured for streamlined publication
 - Implemented Ramda library for functional coding techniques
 ### Changed
-- Breaking: backpat now returns a promise that resolves into an object–so no more callback
+- **Breaking: backpat now returns a promise that resolves into an object–so no more callback**
 - Updated README
 - Refactored codebase to promise syntax
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased (0.6.0 candidate)
 ### Added
-- Configure for streamlined publication
+- Configured for streamlined publication
+- Implemented Ramda library for functional coding techniques
 ### Changed
-- Refactor codebase to promise syntax
+- Breaking: backpat now returns a promise that resolves into an object–so no more callback
+- Updated README
+- Refactored codebase to promise syntax
 
 ## 0.5.1 - 2016-12-15
 ### Added

--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@ Install it as such:
 $ npm install --save backpat
 ```
 
-As of v0.4.0: Require it like so:
+Require it like so:
 
 ```javascript
 const backpat = require('backpat').backpat;
 ```
 
-Invoke it thusly:
+**As of v6.0**: Invoke it thusly:
 
 ```javascript
-backpat(callback);
+backpat();
 ```
 
 And it will parse your project's ```package.json```, identifying all production
-and developer dependencies and fetching the particulars of each. What you'll
-get back is an object like this, if considerably more robust.
+and developer dependencies and fetching the particulars of each. **What you'll
+get back is a promise** that will eventually resolve into an object like this:
 
 ```javascript
 { eslint:
@@ -41,12 +41,7 @@ get back is an object like this, if considerably more robust.
      downloads: 4001598 }}
 ```
 
-Simple as that. The npm download count attribute makes filtering the results
-a snap.
+Simple as that. The npm download count attribute makes ranking and filtering the
+results a snap.
 
-Worth noting: the whole shebang is async – so don't worry if you've got kitchen-
-sink-grade dependencies.
-
-This is a nascent module that is bound to require some TLC. If you encounter
-any rough edges, please don't hesitate to drop me a line. Oh, and _feel free to
-submit at PR_. There's still much to be done.
+That's it. _Feel free to submit an issue or PR_.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const backpat = require('backpat').backpat;
 **As of v6.0**: Invoke it thusly:
 
 ```javascript
-backpat();
+backpat().then(...do stuff with it here...)
 ```
 
 And it will parse your project's ```package.json```, identifying all production

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Backpat [![Build Status](https://img.shields.io/travis/cachilders/backpat/master.svg)](https://travis-ci.org/cachilders/backpat) [![Coverage Status](https://coveralls.io/repos/github/cachilders/backpat/badge.svg?branch=master)](https://coveralls.io/github/cachilders/backpat?branch=master)
+# Backpat [![Build Status](https://travis-ci.org/cachilders/backpat.svg?branch=master)](https://travis-ci.org/cachilders/backpat) [![Coverage Status](https://coveralls.io/repos/github/cachilders/backpat/badge.svg?branch=master)](https://coveralls.io/github/cachilders/backpat?branch=master)
 
 Backpat is a simple tool for use in automating the production of tech stack
 notes in projects. Think along the lines of About pages with links for crediting

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint": "^3.8.1",
     "eslint-plugin-flowtype": "^2.25.0",
     "ghooks": "^1.3.2",
+    "lodash": "^4.17.2",
     "mocha": "^3.1.2",
     "npm-run-all": "^3.1.2",
     "nyc": "^10.0.0",
@@ -72,7 +73,6 @@
     }
   },
   "dependencies": {
-    "lodash": "^4.17.2",
     "ramda": "^0.22.1"
   }
 }

--- a/runner.js
+++ b/runner.js
@@ -2,6 +2,5 @@ let util = require('util');
 let backpat = require('./dist/index').backpat;
 
 // Run this script to test Backpat's output
-
-backpat((result) => process.stdout.write(util.format(result) + '\n')); // formatted
-// backpat((result) => process.stdout.write(JSON.stringify(result) + '\n')); //unformatted
+const print = (result) => process.stdout.write(util.format(result) + '\n');
+backpat().then(print);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -2,7 +2,7 @@
 
 import https from 'https';
 import { readFile } from 'fs';
-import { formatVersionsAndFilterPrivate } from './utilities';
+import { formatVersions } from './utilities';
 
 export const rootDir = process.cwd() + '/';
 export const nodeDetails = {
@@ -38,9 +38,9 @@ export function instantiateDependencies(packageJson: {}) {
     const dependencies = {};
     Object.assign(dependencies,
       packageJson.dependencies ? 
-        formatVersionsAndFilterPrivate(packageJson.dependencies) : null,
-      packageJson.devDependencies?
-        formatVersionsAndFilterPrivate(packageJson.devDependencies): null,
+        formatVersions(packageJson.dependencies) : null,
+      packageJson.devDependencies ?
+        formatVersions(packageJson.devDependencies): null,
     );
     resolve(dependencies);
   });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,6 +5,15 @@ import { readFile } from 'fs';
 import { formatVersionsAndFilterPrivate } from './utilities';
 
 export const rootDir = process.cwd() + '/';
+export const nodeDetails = {
+  node: {
+    name        : 'Node.js',
+    url         : 'https://nodejs.org',
+    version     : process.versions.node,
+    description : 'A JavaScript runtime ✨🐢🚀✨',
+    downloads   : 10000000 // A fake number since Node isn't downloaded on npm
+  }
+};
 
 export const readPackageJson = (path: string = rootDir) => {
   if (typeof path !== 'string') {
@@ -90,3 +99,5 @@ export function httpsGetPromise(opts: {}) {
     });
   });
 }
+
+export const addNode = (dependencies: {}) => Object.assign({}, dependencies, nodeDetails);

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -4,6 +4,7 @@ import {
   NpmConfig,
   readPackageJson,
   rootDir,
+  instantiateDependencies,
   fetchEachDependency,
   fetchDependency,
   resolveDependency,
@@ -65,6 +66,60 @@ describe('Helpers', function() {
         );
         done();
       });
+    });
+
+  });
+
+  describe('instantiateDependencies', () => {
+
+    const deps = {
+      dependencies: {
+        flashy: '^3.5.0', stuff: '^0.7.1'
+      }
+    };
+
+    const devDeps = {
+      devDependencies: {
+        chai: '^3.5.0', coveralls: '^2.11.15'
+      }
+    };
+
+    it('should be a function', () => {
+      expect(instantiateDependencies).to.be.a('function');
+    });
+
+    it('should return a promise when passed an object', () => {
+      expect(instantiateDependencies(deps)).to.be.an.instanceof(Promise);
+    });
+
+    it('returned promise should eventually resolve into an object', (done) => {
+      instantiateDependencies({})
+      .then((result) => expect(result).to.be.an('object'));
+      done();
+    });
+
+    it('resolved promise should be an empty object when provided no \'dependencies\' or \'devDependencies\' keys', (done) => {
+      instantiateDependencies({})
+      .then((result) => expect(result).to.have.all.keys([]));
+      done();
+    });
+
+    it('resolved promise should be an object when given only \'dependencies\'', (done) => {
+      instantiateDependencies(deps)
+      .then((result) => expect(result).to.have.all.keys(['flashy', 'stuff']));
+      done();
+    });
+
+    it('resolved promise should be an object when given only \'devDependencies\'', (done) => {
+      instantiateDependencies(devDeps)
+      .then((result) => expect(result).to.have.all.keys(['chai', 'coveralls']));
+      done();
+    });
+
+    it('resolved promise should be an object when given both \'dependencies\' and \'devDependencies\'', (done) => {
+      instantiateDependencies(Object.assign(deps, devDeps))
+      .then((result) => expect(result).to.have.all.keys(['flashy', 'stuff', 'chai', 'coveralls']));
+      done();
     });
 
   });

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -6,7 +6,9 @@ import {
   rootDir,
   fetchEachDependency,
   fetchDependency,
-  resolveDependency
+  resolveDependency,
+  addNode,
+  nodeDetails
 } from './helpers';
 import { getNpmData } from './utilities';
 
@@ -15,11 +17,15 @@ chai.use(chaiSpies);
 describe('Helpers', function() {
 
   describe('rootDir', () => {
-
     it('should be a string', () => {
       expect(rootDir).to.be.a('string');
     });
+  });
 
+  describe('nodeDetails', () => {
+    it('should be an object', () => {
+      expect(nodeDetails).to.be.an('object');
+    });
   });
 
   describe('readPackageJson', () => {
@@ -204,4 +210,11 @@ describe('Helpers', function() {
     });
 
   });
+
+  describe('addNode', () => {
+    it('should be a function', () => {
+      expect(addNode).to.be.a('function');
+    });
+  });
+
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,12 @@
 /* @flow */
 
-import { getNpmData, curriedMerge, pickDownloads, addNode } from './utilities';
+import { getNpmData, curriedMerge, pickDownloads } from './utilities';
 import {
   readPackageJson,
   fetchEachDependency,
-  instantiateDependencies } from './helpers';
+  instantiateDependencies,
+  addNode
+ } from './helpers';
 
 export function backpat(f: Function) {
   if (typeof f !== 'function') {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import {
   readPackageJson,
   fetchEachDependency,
   instantiateDependencies,
+  filterPrivate,
   addNode
  } from './helpers';
 
@@ -19,6 +20,7 @@ export function backpat() {
       .then(merge);
     })
     .then(fetchEachDependency)
+    .then(filterPrivate)
     .then(addNode)
     .then((dependencies) => resolve(dependencies))
     .catch(console.error);

--- a/src/index.js
+++ b/src/index.js
@@ -8,11 +8,8 @@ import {
   addNode
  } from './helpers';
 
-export function backpat(f: Function) {
-  if (typeof f !== 'function') {
-    throw new TypeError(`Function backpat expected input type: function but received ${ typeof f } instead`);
-  }
-  return new Promise(() => {
+export function backpat() {
+  return new Promise((resolve) => {
     readPackageJson()
     .then(instantiateDependencies)
     .then((dependencies) => {
@@ -23,6 +20,7 @@ export function backpat(f: Function) {
     })
     .then(fetchEachDependency)
     .then(addNode)
-    .then(f);
+    .then((dependencies) => resolve(dependencies))
+    .catch(console.error);
   });
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -10,11 +10,11 @@ describe('Backpat', () => {
     expect(backpat).to.be.a('function');
   });
 
-  it('should return a promise object when passed callback', () => {
+  it('should return a promise object when invoked', () => {
     expect(backpat(() => {})).to.be.an.instanceof(Promise);
   });
 
-  it('should eventually return an object', (done) => {
+  it('should eventually resolve into an object', (done) => {
     backpat().then((dependencies) => {
       expect(dependencies).to.be.an('object');
       done();

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -10,29 +10,15 @@ describe('Backpat', () => {
     expect(backpat).to.be.a('function');
   });
 
-  it('should accept a single function as its parameter', () => {
-    expect(backpat).to.have.lengthOf(1);
-    expect(() => { backpat('string'); }).to.throw(TypeError);
-    expect(() => { backpat(42); }).to.throw(TypeError);
-    expect(() => { backpat(true); }).to.throw(TypeError);
-  });
-
   it('should return a promise object when passed callback', () => {
     expect(backpat(() => {})).to.be.an.instanceof(Promise);
   });
 
-  const callback = () => {};
-
-  it('should accept a function as its argument', () => {
-    const spy = chai.spy(callback);
-    expect(spy).to.be.spy;
-    // asynchronous nature of backpat function makes this very difficult to test
-    // vars.event.on('complete', expect(spy).to.have.been.called.once());
-  });
-
-  it('should throw TypeError when backpat not passed function as argument', () => {
-    expect( () => { backpat(callback); }).to.not.throw(TypeError);
-    expect(backpat).to.throw(TypeError);
+  it('should eventually return an object', (done) => {
+    backpat().then((dependencies) => {
+      expect(dependencies).to.be.an('object');
+      done();
+    });
   });
 
 });

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -5,10 +5,9 @@ const removeCaret = R.replace(/\^/, '');
 const addVersionProp = (v, k, o) => o[k] = { 'version': removeCaret(v) };
 const isNotPrivate = R.compose(R.not, R.prop('private'));
 const deeplyMerge = (obj1, obj2) => R.mapObjIndexed((v, k, o) => R.merge(obj1[k], obj2[k]), obj1);
-const pickProps = R.curry(R.pick);
 
 export const formatVersions = R.mapObjIndexed(addVersionProp);
 export const curriedMerge = R.curry(deeplyMerge);
 export const getNpmData = R.compose(httpsGetPromise, NpmConfig);
-export const pickDownloads = R.map(pickProps(['downloads']));
+export const pickDownloads = R.map(R.pick(['downloads']));
 export const filterPrivate = R.filter(isNotPrivate);

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -6,6 +6,13 @@ const addVersionProp = (v, k, o) => o[k] = { 'version': removeCaret(v) };
 const isNotPrivate = R.compose(R.not, R.prop('private'));
 const deeplyMerge = (obj1, obj2) => R.mapObjIndexed((v, k, o) => R.merge(obj1[k], obj2[k]), obj1);
 
+export default {
+  removeCaret: removeCaret,
+  addVersionProp: addVersionProp,
+  isNotPrivate: isNotPrivate,
+  deeplyMerge: deeplyMerge
+};
+
 export const formatVersions = R.mapObjIndexed(addVersionProp);
 export const curriedMerge = R.curry(deeplyMerge);
 export const getNpmData = R.compose(httpsGetPromise, NpmConfig);

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -1,31 +1,14 @@
 import R from 'ramda';
 import { NpmConfig, httpsGetPromise } from './helpers';
 
-const addVersionProp = (val, key, obj) => obj[key] = { 'version': removeCaret(val) };
 const removeCaret = R.replace(/\^/, '');
+const addVersionProp = (v, k, o) => o[k] = { 'version': removeCaret(v) };
 const isNotPrivate = R.compose(R.not, R.prop('private'));
 const filterPrivate = R.filter(isNotPrivate);
+const deeplyMerge = (obj1, obj2) => R.mapObjIndexed((v, k, o) => R.merge(obj1[k], obj2[k]), obj1);
 const pickProps = R.curry(R.pick);
 
-const deeplyMerge = (obj1, obj2) => {
-  return R.keys(obj1).reduce((result, key) => {
-    result[key] = R.merge(obj1[key], obj2[key]);
-    return result;
-  }, {});
-};
-
-export const addNode = (obj) => {
-  obj.node = {
-    name        : 'Node.js',
-    url         : 'https://nodejs.org',
-    version     : process.versions.node,
-    description : 'A JavaScript runtime ✨🐢🚀✨',
-    downloads   : 10000000 // A fake number since Node isn't downloaded on npm
-  };
-  return obj;
-};
-
-export const pickDownloads = R.map(pickProps(['downloads']));
-export const curriedMerge = R.curry(deeplyMerge);
 export const formatVersionsAndFilterPrivate = R.compose(R.mapObjIndexed(addVersionProp), filterPrivate);
+export const curriedMerge = R.curry(deeplyMerge);
 export const getNpmData = R.compose(httpsGetPromise, NpmConfig);
+export const pickDownloads = R.map(pickProps(['downloads']));

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -5,17 +5,11 @@ const addVersionProp = (val, key, obj) => obj[key] = { 'version': removeCaret(va
 const removeCaret = R.replace(/\^/, '');
 const isNotPrivate = R.compose(R.not, R.prop('private'));
 const filterPrivate = R.filter(isNotPrivate);
+const pickProps = R.curry(R.pick);
 
 const deeplyMerge = (obj1, obj2) => {
   return R.keys(obj1).reduce((result, key) => {
     result[key] = R.merge(obj1[key], obj2[key]);
-    return result;
-  }, {});
-};
-
-export const pickDownloads = (obj) => {
-  return R.keys(obj).reduce((result, key) => {
-    result[key] = R.pick(['downloads'], obj[key]);
     return result;
   }, {});
 };
@@ -31,6 +25,7 @@ export const addNode = (obj) => {
   return obj;
 };
 
+export const pickDownloads = R.map(pickProps(['downloads']));
 export const curriedMerge = R.curry(deeplyMerge);
 export const formatVersionsAndFilterPrivate = R.compose(R.mapObjIndexed(addVersionProp), filterPrivate);
 export const getNpmData = R.compose(httpsGetPromise, NpmConfig);

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -4,11 +4,11 @@ import { NpmConfig, httpsGetPromise } from './helpers';
 const removeCaret = R.replace(/\^/, '');
 const addVersionProp = (v, k, o) => o[k] = { 'version': removeCaret(v) };
 const isNotPrivate = R.compose(R.not, R.prop('private'));
-const filterPrivate = R.filter(isNotPrivate);
 const deeplyMerge = (obj1, obj2) => R.mapObjIndexed((v, k, o) => R.merge(obj1[k], obj2[k]), obj1);
 const pickProps = R.curry(R.pick);
 
-export const formatVersionsAndFilterPrivate = R.compose(R.mapObjIndexed(addVersionProp), filterPrivate);
+export const formatVersions = R.mapObjIndexed(addVersionProp);
 export const curriedMerge = R.curry(deeplyMerge);
 export const getNpmData = R.compose(httpsGetPromise, NpmConfig);
 export const pickDownloads = R.map(pickProps(['downloads']));
+export const filterPrivate = R.filter(isNotPrivate);

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -2,8 +2,7 @@ import chai, { expect } from 'chai';
 import {
   pickDownloads,
   curriedMerge,
-  formatVersionsAndFilterPrivate,
-  addNode
+  formatVersionsAndFilterPrivate
 } from './utilities';
 
 describe('Utilities', () => {
@@ -23,12 +22,6 @@ describe('Utilities', () => {
   describe('formatVersionsAndFilterPrivate', () => {
     it('should be a function', () => {
       expect(formatVersionsAndFilterPrivate).to.be.a('function');
-    });
-  });
-
-  describe('addNode', () => {
-    it('should be a function', () => {
-      expect(addNode).to.be.a('function');
     });
   });
 

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -1,4 +1,4 @@
-import chai, { expect } from 'chai';
+import { expect } from 'chai';
 import {
   pickDownloads,
   curriedMerge,

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import {
+import utilities, {
   pickDownloads,
   curriedMerge,
   formatVersions,
@@ -7,6 +7,69 @@ import {
 } from './utilities';
 
 describe('Utilities', () => {
+
+  describe('removeCarat', () => {
+
+    it('should be a function', () => {
+      expect(utilities.removeCaret).to.be.a('function');
+    });
+
+    it('should return a string when provided a string', () => {
+      expect(utilities.removeCaret('^3.5.0')).to.be.a('string');
+    });
+
+    it('should return a string with first caret removed', () => {
+      expect(utilities.removeCaret('s^tring')).to.equal('string');
+    });
+
+    it('should be caret agnostic re: strings', () => {
+      expect(utilities.removeCaret('string')).to.equal('string');
+    });
+
+  });
+
+  describe('addVersionProp', () => {
+
+    it('should be a function', () => {
+      expect(utilities.addVersionProp).to.be.a('function');
+    });
+
+    // TODO: This one is a little reliant on the calling mapObjIndexed function. Requires a little
+    // consideration, but the core functionality is presently tested via formatVersions.
+
+    // it('should return an object when passed an object', () => {
+    //   expect(utilities.addVersionProp(dep)).to.be.an('object');
+    // });
+
+    // it('should return an empty object when passed an empty object', () => {
+    //   expect(utilities.addVersionProp({})).to.have.all.keys([]);
+    // });
+
+    // it('returned object should contain nested object with version key when passed dependency', () => {
+    //   expect(utilities.addVersionProp(dep).chai).to.have.all.keys(['version']);
+    // });
+
+  });
+
+  describe('isNotPrivate', () => {
+
+    it('should be a function', () => {
+      expect(utilities.isNotPrivate).to.be.a('function');
+    });
+
+    // TODO: Tangentially tested as aspect of filterPrivate
+
+  });
+
+  describe('deeplyMerge', () => {
+
+    it('should be a function', () => {
+      expect(utilities.deeplyMerge).to.be.a('function');
+    });
+
+    // TODO: Tangentially tested as core function of curriedMerge
+
+  });
 
   describe('pickDownloads', () => {
 

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -2,27 +2,129 @@ import { expect } from 'chai';
 import {
   pickDownloads,
   curriedMerge,
-  formatVersionsAndFilterPrivate
+  formatVersions,
+  filterPrivate
 } from './utilities';
 
 describe('Utilities', () => {
 
   describe('pickDownloads', () => {
+
+    const npmData = {
+      a: {downloads: '3', garbage: 'trash'},
+      b: {garbage: 'trash'}
+    };
+
     it('should be a function', () => {
       expect(pickDownloads).to.be.a('function');
     });
+
+    const strippedObject = pickDownloads(npmData);
+
+    it('should return an object when passed an object', () => {
+      expect(strippedObject).to.be.an('object');
+    });
+
+    it('should return nested objects containing only \'downloads\' prop', () => {
+      expect(strippedObject.a).to.have.all.keys(['downloads']);
+    });
+
+    it('should return empty nested objects when \'downloads\' key not present', () => {
+      expect(Object.keys(strippedObject.b).length).to.equal(0);
+    });
+
   });
 
   describe('curriedMerge', () => {
+
+    const dependencies = {
+      a: {name: "Cheese", version: "1"},
+      b: {name: "Burger", version: "3"}
+    };
+
+    const npmData = {
+      a: {downloads: '3'},
+      b: {downloads: '1'}
+    };
+
     it('should be a function', () => {
       expect(curriedMerge).to.be.a('function');
     });
+
+    const mergeDependenciesWith = curriedMerge(dependencies);
+
+    it('should return a function when passed an object', () => {
+      expect(mergeDependenciesWith).to.be.a('function');
+    });
+
+    const mergedObject = mergeDependenciesWith(npmData);
+
+    it('returned function should return an object when passed an object', () => {
+      expect(mergedObject).to.be.an('object');
+    });
+
+    it('final object should contain nested objects with merged keys', () => {
+      expect(mergedObject.a).to.have.all.keys(['name', 'version', 'downloads']);
+    });
+
   });
 
-  describe('formatVersionsAndFilterPrivate', () => {
+  describe('formatVersions', () => {
+
+    const deps = {
+      chai: '^3.5.0',
+      'chai-spies': '^0.7.1',
+      commitizen: '^2.9.0',
+      coveralls: '^2.11.15',
+    };
+
     it('should be a function', () => {
-      expect(formatVersionsAndFilterPrivate).to.be.a('function');
+      expect(formatVersions).to.be.a('function');
     });
+
+    const formattedDeps = formatVersions(deps);
+
+    it('should return an object when passed an object', () => {
+      expect(formattedDeps).to.be.an('object');
+    });
+
+    it('returned object should contain nested objects with version key', () => {
+      expect(formattedDeps.chai).to.have.all.keys(['version']);
+    });
+
+    it('nested version strings should be properly formatted', () => {
+      expect(formattedDeps.coveralls.version).to.equal('2.11.15');
+    });
+
+  });
+
+  describe('filterPrivate', () => {
+
+    const deps = {
+      chai: {private: true},
+      'chai-spies': {private: false},
+      commitizen: {},
+      coveralls: {private: 'yes'},
+    };
+
+    it('should be a function', () => {
+      expect(filterPrivate).to.be.a('function');
+    });
+
+    const filteredDeps = filterPrivate(deps);
+
+    it('should return an object when passed an object', () => {
+      expect(filteredDeps).to.be.an('object');
+    });
+
+    it('returned object should contain public dependencies', () => {
+      expect(filteredDeps).to.have.all.keys(['chai-spies', 'commitizen']);
+    });
+
+    it('returned object should not contain private dependencies', () => {
+      expect(filteredDeps).to.not.have.any.keys(['chai', 'coveralls']);
+    });
+
   });
 
 });

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -3,8 +3,33 @@ import {
   pickDownloads,
   curriedMerge,
   formatVersionsAndFilterPrivate,
-  getNpmData,
   addNode
 } from './utilities';
 
-// TODO
+describe('Utilities', () => {
+
+  describe('pickDownloads', () => {
+    it('should be a function', () => {
+      expect(pickDownloads).to.be.a('function');
+    });
+  });
+
+  describe('curriedMerge', () => {
+    it('should be a function', () => {
+      expect(curriedMerge).to.be.a('function');
+    });
+  });
+
+  describe('formatVersionsAndFilterPrivate', () => {
+    it('should be a function', () => {
+      expect(formatVersionsAndFilterPrivate).to.be.a('function');
+    });
+  });
+
+  describe('addNode', () => {
+    it('should be a function', () => {
+      expect(addNode).to.be.a('function');
+    });
+  });
+
+});


### PR DESCRIPTION
This is a fairly significant line reduction in the Ramda `utilities.js` file, clarifying the push toward a more functional structure. Key refactors include the `deeplyMerge` and `pickDownloads` functions, used to process the results of scraping module `package.json` files and a bulk XHR to npm respectively. There are also minimal, provisional test refactorings.